### PR TITLE
Use lexists for broken symlink

### DIFF
--- a/cudnnenv/__init__.py
+++ b/cudnnenv/__init__.py
@@ -136,7 +136,7 @@ def ensure_exist(ver):
 
 def remove_link():
     symlink_path = get_active_path()
-    if os.path.exists(symlink_path):
+    if os.path.lexists(symlink_path):
         os.remove(symlink_path)
 
 


### PR DESCRIPTION
When a broken symlink exits `os.path.exists` returns False and it does not remove the link. I instead use `os.path.lexists`.