### PR TITLE
Support cuDNN 7.0.4 and update an alias

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ Use `activate` subcommand to only activate installed version.
 
 positional arguments:
 
-:`VERSION`: Version of cuDNN you want to install and activate. Select from [v2, v3, v4, v5, v5-cuda8, v51, v51-cuda8, v6, v6-cuda8, v7-cuda8, v7-cuda9, v7.0.1-cuda8, v7.0.1-cuda9, v7.0.2-cuda8, v7.0.2-cuda9, v7.0.3-cuda8, v7.0.3-cuda9]
+:`VERSION`: Version of cuDNN you want to install and activate. Select from [v2, v3, v4, v5, v5-cuda8, v51, v51-cuda8, v6, v6-cuda8, v7-cuda8, v7-cuda9, v7.0.1-cuda8, v7.0.1-cuda9, v7.0.2-cuda8, v7.0.2-cuda9, v7.0.3-cuda8, v7.0.3-cuda9, v7.0.4-cuda8, v7.0.4-cuda9]
 
-Note that `v7-cuda8` is not available on macOS.
+Note that `v7*-cuda8` and `v7.0.4-cuda9` are not available on macOS.
 
 `install-file`
 ~~~~~~~~~~~~~~

--- a/cudnnenv/__init__.py
+++ b/cudnnenv/__init__.py
@@ -135,8 +135,20 @@ rm {cudnn}.tgz
         sha256sum='09583e93110cee2bf76ea355e1d9c7c366a50ad858362064f7c927cc46209ef9',
     )
 
-    codes['v7-cuda8'] = codes['v7.0.3-cuda8']
-    codes['v7-cuda9'] = codes['v7.0.3-cuda9']
+    codes['v7.0.4-cuda8'] = cudnn_base.format(
+        cudnn='cudnn-8.0-linux-x64-v7',
+        cudnn_ver='v7.0.4',
+        sha256sum='c9d6e482063407edaa799c944279e5a1a3a27fd75534982076e62b1bebb4af48',
+    )
+
+    codes['v7.0.4-cuda9'] = cudnn_base.format(
+        cudnn='cudnn-9.0-linux-x64-v7',
+        cudnn_ver='v7.0.4',
+        sha256sum='963da2057c298616dab0c754398dcb1cced1bdc5f21ca00258b149f709b5bc4f',
+    )
+
+    codes['v7-cuda8'] = codes['v7.0.4-cuda8']
+    codes['v7-cuda9'] = codes['v7.0.4-cuda9']
 
     LIBDIR = 'lib64'
 
@@ -233,7 +245,13 @@ rm {cudnn}.tgz
         sha256sum='ea7e085af13de736e2727a21d2cd0162084afc12b17fdb08b124d0e5280bab11',
     )
 
-    codes['v7-cuda9'] = codes['v7.0.3-cuda9']
+    codes['v7.0.4-cuda9'] = cudnn_base.format(
+        cudnn='cudnn-9.0-osx-x64-v7',
+        cudnn_ver='v7.0.4',
+        sha256sum='b408b7747b74771c6bc382f505961b034b3af4fbaa243e14d5bc6ca8c3c49699',
+    )
+
+    codes['v7-cuda9'] = codes['v7.0.4-cuda9']
 
     LIBDIR = 'lib'
 

--- a/cudnnenv/__init__.py
+++ b/cudnnenv/__init__.py
@@ -245,13 +245,7 @@ rm {cudnn}.tgz
         sha256sum='ea7e085af13de736e2727a21d2cd0162084afc12b17fdb08b124d0e5280bab11',
     )
 
-    codes['v7.0.4-cuda9'] = cudnn_base.format(
-        cudnn='cudnn-9.0-osx-x64-v7',
-        cudnn_ver='v7.0.4',
-        sha256sum='b408b7747b74771c6bc382f505961b034b3af4fbaa243e14d5bc6ca8c3c49699',
-    )
-
-    codes['v7-cuda9'] = codes['v7.0.4-cuda9']
+    codes['v7-cuda9'] = codes['v7.0.3-cuda9']
 
     LIBDIR = 'lib'
 

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -52,7 +52,6 @@ elif sys.platform == 'darwin':
   v7.0.1-cuda9
   v7.0.2-cuda9
   v7.0.3-cuda9
-  v7.0.4-cuda9
 '''
 
 

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -35,6 +35,8 @@ if 'linux' in sys.platform:
   v7.0.2-cuda9
   v7.0.3-cuda8
   v7.0.3-cuda9
+  v7.0.4-cuda8
+  v7.0.4-cuda9
 '''
 elif sys.platform == 'darwin':
     _available_versions = '''  v2
@@ -50,6 +52,7 @@ elif sys.platform == 'darwin':
   v7.0.1-cuda9
   v7.0.2-cuda9
   v7.0.3-cuda9
+  v7.0.4-cuda9
 '''
 
 


### PR DESCRIPTION
Linux version worked fine.
However, tarball for Darwin version seems to be broken and cannot be installed.